### PR TITLE
Add energy conservation to spec gloss model

### DIFF
--- a/extensions/Vendor/FRAUNHOFER_materials_pbr/example/untextured-pbr/index.html
+++ b/extensions/Vendor/FRAUNHOFER_materials_pbr/example/untextured-pbr/index.html
@@ -622,7 +622,7 @@
                         // metallic-roughness workflow
                         if (controls.workflow == 'metallic-roughness')
                         {
-                            customUniforms['baseColorFactor']    = { value: new THREE.Vector4(albedo.r, albedo.g, albedo.r, opacity) };
+                            customUniforms['baseColorFactor']    = { value: new THREE.Vector4(albedo.r, albedo.g, albedo.b, opacity) };
                             customUniforms['metallicFactor']     = { value: metalness };
                             customUniforms['roughnessFactor']    = { value: roughness };
                             customUniforms['reflectivityFactor'] = { value: reflectivity };
@@ -636,8 +636,8 @@
                             var oneMinusSpecularStrength = 1 - Math.max(specular.r, specular.g, specular.b);
                             var diffuse = (oneMinusSpecularStrength < 1e-6) ? new THREE.Color(0, 0, 0) : albedo.clone().multiplyScalar((1 - dielectricSpecular) * (1 - metalness) / oneMinusSpecularStrength);
 
-                            customUniforms['diffuseFactor'] = { value: new THREE.Vector4(diffuse.r, diffuse.g, diffuse.b, opacity) };
-                            customUniforms['specularFactor'] = { value: specular };
+                            customUniforms['diffuseFactor'] =    { value: new THREE.Vector4(diffuse.r, diffuse.g, diffuse.b, opacity) };
+                            customUniforms['specularFactor'] =   { value: specular };
                             customUniforms['glossinessFactor'] = { value: 1 - roughness };
                         }
                     }

--- a/extensions/Vendor/FRAUNHOFER_materials_pbr/example/untextured-pbr/index.html
+++ b/extensions/Vendor/FRAUNHOFER_materials_pbr/example/untextured-pbr/index.html
@@ -73,7 +73,8 @@
 
             vec4 getDiffuseColor()
             {
-                return diffuseFactor;
+                float oneMinusSpecularStrength = 1.0 - max( max( specularFactor.r, specularFactor.g ), specularFactor.b );
+                return vec4( vec3( diffuseFactor ) * oneMinusSpecularStrength, diffuseFactor.a );
             }
 
             float getSpecularRoughness()
@@ -97,7 +98,8 @@
 
             vec4 getDiffuseColor()
             {
-                return vec4( vec3( baseColorFactor ) * ( 1.0 - metallicFactor ), baseColorFactor.a );
+                float dielectricSpecular = 0.16 * reflectivityFactor * reflectivityFactor;
+                return vec4( vec3( baseColorFactor ) * ( 1.0 - dielectricSpecular ) * ( 1.0 - metallicFactor ), baseColorFactor.a );
             }
 
             float getSpecularRoughness()
@@ -107,8 +109,8 @@
 
             vec3 getSpecularColor()
             {
-                float f0 = 0.16 * reflectivityFactor * reflectivityFactor;
-                return mix( vec3( f0 ), vec3( baseColorFactor ), metallicFactor );
+                float dielectricSpecular = 0.16 * reflectivityFactor * reflectivityFactor;
+                return mix( vec3( dielectricSpecular ), vec3( baseColorFactor ), metallicFactor );
             }
         </script>
 
@@ -595,12 +597,12 @@
 
             function updatePBRMaterial()
             {
-                const albedo = new THREE.Vector4(
+                const albedo = new THREE.Color(
                     parseInt(controls.albedo.substring(1, 3), 16) / 255.0,
                     parseInt(controls.albedo.substring(3, 5), 16) / 255.0,
-                    parseInt(controls.albedo.substring(5, 7), 16) / 255.0,
-                    controls.opacity);
+                    parseInt(controls.albedo.substring(5, 7), 16) / 255.0);
 
+                const opacity = controls.opacity;
                 const reflectivity = controls.reflectivity;
 
                 for (var y = 0; y < scene.children.length; y++)
@@ -620,7 +622,7 @@
                         // metallic-roughness workflow
                         if (controls.workflow == 'metallic-roughness')
                         {
-                            customUniforms['baseColorFactor']    = { value: albedo };
+                            customUniforms['baseColorFactor']    = { value: new THREE.Vector4(albedo.r, albedo.g, albedo.r, opacity) };
                             customUniforms['metallicFactor']     = { value: metalness };
                             customUniforms['roughnessFactor']    = { value: roughness };
                             customUniforms['reflectivityFactor'] = { value: reflectivity };
@@ -628,13 +630,15 @@
                         // specular-glossiness workflow
                         else
                         {
-                            var diffuse = new THREE.Vector3(albedo.x, albedo.y, albedo.z).multiplyScalar(1.0 - metalness);
-                            customUniforms['diffuseFactor'] = { value: new THREE.Vector4(diffuse.x, diffuse.y, diffuse.z, albedo.w) };
+                            var dielectricSpecular = 0.16 * reflectivity * reflectivity;
+                            var specular = new THREE.Color(dielectricSpecular, dielectricSpecular, dielectricSpecular).lerp(albedo, metalness);
 
-                            var f0 = 0.16 * reflectivity * reflectivity;
-                            customUniforms['specularFactor'] = { value: new THREE.Vector3(f0, f0, f0).lerp(new THREE.Vector3(albedo.x, albedo.y, albedo.z), metalness) };
+                            var oneMinusSpecularStrength = 1 - Math.max(specular.r, specular.g, specular.b);
+                            var diffuse = (oneMinusSpecularStrength < 1e-6) ? new THREE.Color(0, 0, 0) : albedo.clone().multiplyScalar((1 - dielectricSpecular) * (1 - metalness) / oneMinusSpecularStrength);
 
-                            customUniforms['glossinessFactor'] = { value: 1.0 - roughness };
+                            customUniforms['diffuseFactor'] = { value: new THREE.Vector4(diffuse.r, diffuse.g, diffuse.b, opacity) };
+                            customUniforms['specularFactor'] = { value: specular };
+                            customUniforms['glossinessFactor'] = { value: 1 - roughness };
                         }
                     }
                 }


### PR DESCRIPTION
I had missed some energy conservation math in the specular-glossiness model in the original PR. This fixed that. The conversion is based on the math outlined here: #810